### PR TITLE
Android: add wrapper view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { StyleSheet, useWindowDimensions, View } from 'react-native';
-import { Spinner } from './Spinner';
+import { Spinner, SpinnerAndroid } from './Spinner';
 
 export default function App() {
   const windowWidth = useWindowDimensions().width;
@@ -12,7 +12,13 @@ export default function App() {
     <View style={styles.container}>
       <Spinner
         width={spinnerWidth}
-        color="#f33"
+        color="#ff3333"
+        backgroundColor="#ddd"
+        style={{ width: spinnerViewWidth, height: spinnerViewWidth, marginBottom: 10 }}
+      />
+      <SpinnerAndroid
+        width={spinnerWidth}
+        color="#ff3333"
         backgroundColor="#ddd"
         style={{ width: spinnerViewWidth, height: spinnerViewWidth }}
       />

--- a/Spinner.tsx
+++ b/Spinner.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { StyleSheet, StyleProp, View, ViewStyle } from 'react-native';
 
+const CIRCLE_RADIUS = 9999;
+
 export const Spinner: React.VFC<{
   width?: number | undefined | null;
   color?: string | undefined | null;
@@ -15,15 +17,57 @@ export const Spinner: React.VFC<{
     <View
       style={[
         {
-          borderRadius: 9999,
+          borderRadius: CIRCLE_RADIUS,
           borderColor: backgroundColor,
           borderTopWidth: width,
+          borderTopColor: color,
           borderRightWidth: width,
           borderBottomWidth: width,
           borderLeftWidth: width,
-          borderTopColor: color,
         },
         style,
       ]}></View>
+  );
+};
+
+export const SpinnerAndroid: React.VFC<{
+  width?: number | undefined | null;
+  color?: string | undefined | null;
+  backgroundColor?: string | undefined | null;
+  style?: StyleProp<ViewStyle>;
+}> = ({ width: widthParam, color: colorParam, backgroundColor: backgroundColorParam, style }) => {
+  const width = widthParam ?? 5;
+  const color = colorParam ?? 'white';
+  const backgroundColor = backgroundColorParam ?? 'rgba(255, 255, 255, 0.6)';
+
+  // In Android, borderRadius + borderXXXWidth is not properly working.
+  // To get around this problem, I use a wrapper view for spin.
+  //
+  // https://github.com/facebook/react-native/issues/9262
+  return (
+    <View>
+      <View
+        style={[
+          {
+            position: 'absolute',
+            borderRadius: CIRCLE_RADIUS,
+            borderColor: backgroundColor,
+            borderWidth: width,
+          },
+          style,
+        ]}></View>
+      <View
+        style={[
+          {
+            borderRadius: CIRCLE_RADIUS,
+            borderColor: backgroundColor,
+            borderTopWidth: width,
+            borderTopColor: color,
+            borderRightWidth: width,
+            borderLeftWidth: width,
+          },
+          style,
+        ]}></View>
+    </View>
   );
 };


### PR DESCRIPTION
In Android, borderRadius + borderXXXWidth is not properly working. To get around this problem, I use a wrapper view for spin.

Ref: https://github.com/facebook/react-native/issues/9262

**iOS**
![IMG_B0AF366ACB93-1](https://user-images.githubusercontent.com/18448/125791652-f966cb3c-5c68-46e7-b099-f6583af30b3e.jpeg)

**Android**
![Screenshot (2021_07_15 21_56_11)](https://user-images.githubusercontent.com/18448/125791942-84a81b0f-0b1b-44ee-8f9f-65716cb388a3.png)

